### PR TITLE
Use atomic.OrUint32 to set bits in SyncFilter

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,12 +9,12 @@ jobs:
   test:
     strategy:
       matrix:
-        goversion: [1.16, 1.19]
+        goversion: [1.16, 1.19, 1.23]
     runs-on: ubuntu-latest
 
     steps:
       - name: Install Go
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@v4
         with:
           go-version: ${{ matrix.goversion }}
       - name: Checkout
@@ -39,7 +39,7 @@ jobs:
 
     steps:
       - name: Install Go
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@v4
         with:
           go-version: 1.19
       - name: Install QEMU

--- a/sync.go
+++ b/sync.go
@@ -127,19 +127,3 @@ func getbitAtomic(b *block, i uint32) bool {
 	x := atomic.LoadUint32(&(*b)[(i/wordSize)%blockWords])
 	return x&bit != 0
 }
-
-// setbit sets bit (i modulo BlockBits) of b, atomically.
-func setbitAtomic(b *block, i uint32) {
-	bit := uint32(1) << (i % wordSize)
-	p := &(*b)[(i/wordSize)%blockWords]
-
-	for {
-		old := atomic.LoadUint32(p)
-		if old&bit != 0 {
-			// Checking here instead of checking the return value from
-			// the CAS is between 50% and 80% faster on the benchmark.
-			return
-		}
-		atomic.CompareAndSwapUint32(p, old, old|bit)
-	}
-}

--- a/sync_go124.go
+++ b/sync_go124.go
@@ -1,0 +1,27 @@
+// Copyright 2024 the Blobloom authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build go1.24
+// +build go1.24
+
+package blobloom
+
+import "sync/atomic"
+
+// setbit sets bit (i modulo BlockBits) of b, atomically.
+func setbitAtomic(b *block, i uint32) {
+	bit := uint32(1) << (i % wordSize)
+	p := &(*b)[(i/wordSize)%blockWords]
+	atomic.OrUint32(p, bit)
+}

--- a/sync_nogo124.go
+++ b/sync_nogo124.go
@@ -1,0 +1,36 @@
+// Copyright 2024 the Blobloom authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build !go1.24
+// +build !go1.24
+
+package blobloom
+
+import "sync/atomic"
+
+// setbit sets bit (i modulo BlockBits) of b, atomically.
+func setbitAtomic(b *block, i uint32) {
+	bit := uint32(1) << (i % wordSize)
+	p := &(*b)[(i/wordSize)%blockWords]
+
+	for {
+		old := atomic.LoadUint32(p)
+		if old&bit != 0 {
+			// Checking here instead of checking the return value from
+			// the CAS is between 50% and 80% faster on the benchmark.
+			return
+		}
+		atomic.CompareAndSwapUint32(p, old, old|bit)
+	}
+}


### PR DESCRIPTION
Merge after Go 1.23 is released and bump Go version in .github/workflows. Then, reconsider whether a separate SyncFilter type is still needed.